### PR TITLE
Point Cargo.toml documentation to docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,4 @@ keywords = ["spmc", "channel", "queue"]
 authors = ["Sean McArthur <sean.monstar@gmail.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/seanmonstar/spmc"
-documentation = "http://seanmonstar.github.io/spmc"
+documentation = "https://docs.rs/spmc"


### PR DESCRIPTION
This points the crates.io documentation link to docs.rs in line with b7f8dd5107b3cf4fd33cb01d3cbf3f2bcf44d4b8, and fixes #2.